### PR TITLE
Update Readme and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN ansible-galaxy collection install community.postgresql
 
 RUN ansible-playbook pb_nautobot_install.yml
 
+RUN pip uninstall -y ansible && apt-get clean
+
 EXPOSE 8000/tcp
 
 CMD /usr/local/bin/supervisord -c /etc/supervisord.conf

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `Nautobot Lab` is an all-in-one docker container that allows a user to quickly get an instance of Nautobot up and running with minimal effort, for the purposes of kicking the tires. With that said; `nautobot-lab` is **NOT** a ready for production container image.
 
 ## Running from Docker Hub
-Building the container isn't needed to get up and running quickly. The image is hosted on Docker Hub for public consumption. Since the image is an all-in-on container, it will take a a few seconds for all of the services to start and stabalize. Once the container has started and all services have stabalized, the web interface can be accessed via `http://localhost:8000`.
+Building the container yourself isn't needed to get up and running quickly. The image is hosted on Docker Hub for public consumption, and you can download and start it with a single command. Since the image is an all-in-one container, it will take a few seconds to download the container, then a few seconds more for all of the services to start and stabilize. Once the container has started and all services have stabilized, the web interface can be accessed via `http://localhost:8000`.
 ```
 docker run -itd --name nautobot -p 8000:8000 networktocode/nautobot-lab
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Nautobot Lab
 
+> This is **not** for production.
+
 `Nautobot Lab` is an all-in-one docker container that allows a user to quickly get an instance of Nautobot up and running with minimal effort, for the purposes of kicking the tires. With that said; `nautobot-lab` is **NOT** a ready for production container image.
 
 ## Running from Docker Hub

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
 # Nautobot Lab
 
-`Nautobot Lab` is an all-in-one docker container that allows a user to quickly get an instance of nautobot up and running with minimal effort, for the purposes of kicking the tires.
+`Nautobot Lab` is an all-in-one docker container that allows a user to quickly get an instance of Nautobot up and running with minimal effort, for the purposes of kicking the tires. With that said; `nautobot-lab` is **NOT** a ready for production container image.
+
+## Running from Docker Hub
+Building the container isn't needed to get up and running quickly. The image is hosted on Docker Hub for public consumption. Since the image is an all-in-on container, it will take a a few seconds for all of the services to start and stabalize. Once the container has started and all services have stabalized, the web interface can be accessed via `http://localhost:8000`.
+```
+docker run -itd --name nautobot -p 8000:8000 networktocode/nautobot-lab
+```
 
 ## Building the container
+The container can be built locally, if preferred.
+
+1. Clone the repository.
+```
+git clone https://github.com/nautobot/nautobot-lab.git
+```
+2. Enter the `nautobot-lab` directory.
+3. Build the image.
 ```
 docker build -t nautobot-lab:latest .
 ```
 
-## Running the container
-It will take a few seconds for all the services to start up and stabalize in the container. Once the services start, the web interface can be accessed via `http://localhost:8000`.
+### Running the container from a local build
+
 ```
 docker run -itd --name nautobot -p 8000:8000 nautobot-lab
 ```


### PR DESCRIPTION
This addresses:
1. #5 - By performing a little bit of clean up towards the end of the container build.
2. #1 - By adding a disclaimer that `nautobot-lab` is not intended for production workloads.

It also updates the `README` and points most of the potential user base to the pre-built container on Docker Hub.  