### PR TITLE
Rename `nautobot-rq` to `nautobot-worker`

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -37,10 +37,10 @@ stdout_logfile=/opt/nautobot/nautobot-app.log
 stderr_logfile=/opt/nautobot/nautobot-app-error.log
 
 
-[program:nautobot-rq]
+[program:nautobot-worker]
 command=/usr/local/bin/nautobot-server rqworker
 startsecs=10
 autostart=true
 autorestart=true
-stdout_logfile=/opt/nautobot/nautobot-rq.log
-stderr_logfile=/opt/nautobot/nautobot-rq-error.log
+stdout_logfile=/opt/nautobot/nautobot-worker.log
+stderr_logfile=/opt/nautobot/nautobot-worker-error.log


### PR DESCRIPTION
I am suggesting this to assert consistency in naming of services from our primary install docs to here. We are planning to switch from RQ to Celery in the near future, so just having it named "worker" is somewhat forward-looking.