### PR TITLE
Add Supervisord Healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,6 @@ VOLUME /var/lib/redis
 
 VOLUME /var/lib/postgresql/12/main
 
+HEALTHCHECK CMD supervisorctl status || exit 1
+
 CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,3 +1,11 @@
+[unix_http_server]
+file=/var/tmp/supervisor.sock
+chmod=0770
+chown=root:root
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [supervisord]
 http_port=/var/tmp/supervisor.sock          ; (default is to run a UNIX domain socket server)
 logfile=/var/tmp/supervisord.log            ; (main log file;default $CWD/supervisord.log)


### PR DESCRIPTION
This fixes #2 by using `supervisorctl` to monitor the status of the Nautobot app, Nautobot Worker, Redis, and Postgresql.

This is what is looks like when all services, managed by supervisord are running:

```
root@ea8e263f703b:/opt/nautobot# supervisorctl status || exit 1
nautobot                         RUNNING   pid 9, uptime 0:04:29
nautobot-worker                  RUNNING   pid 10, uptime 0:04:29
postgresql-server                RUNNING   pid 11, uptime 0:04:29
redis-server                     RUNNING   pid 12, uptime 0:04:29
```

This is what it looks like when you stop a service and recheck.

```
root@ea8e263f703b:/opt/nautobot# supervisorctl stop redis-server
redis-server: stopped
root@ea8e263f703b:/opt/nautobot# supervisorctl status || exit 1
nautobot                         RUNNING   pid 9, uptime 0:05:34
nautobot-worker                  BACKOFF   Exited too quickly (process log may have details)
postgresql-server                RUNNING   pid 11, uptime 0:05:34
redis-server                     STOPPED   Mar 08 08:58 AM
exit
```

The `|| exit 1` will exit upon a exit status of `1`. This informs the Docker Healthcheck that the container is in an unhealthy state.