### PR TITLE
Update Docker Image to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/ubuntu/ubuntu:20.04_stable 
+FROM public.ecr.aws/ubuntu/ubuntu:22.04_stable
 
 ENV NAUTOBOT_VERSION="1.5.19"
 
@@ -36,7 +36,7 @@ RUN apt-get update -y && \
     ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
     apt-get install -y python3 python3-psycopg2 python3-pip \
-      python3-venv python3-dev python3-apt postgresql-12 \
+      python3-venv python3-dev python3-apt postgresql-14 \
       libpq-dev redis-server systemctl git --no-install-recommends && \
     pip3 install --no-cache-dir pip setuptools wheel --upgrade && \
     pip3 install --no-cache-dir --requirement ./templates/requirements.txt && \

--- a/pb_nautobot_install.yml
+++ b/pb_nautobot_install.yml
@@ -54,7 +54,7 @@
     - name: "UPDATE PG_HBA.CONF"
       ansible.builtin.template:
         src: "pg_hba.conf"
-        dest: "/etc/postgresql/12/main/pg_hba.conf"
+        dest: "/etc/postgresql/14/main/pg_hba.conf"
         owner: "postgres"
         group: "postgres"
         mode: "0600"

--- a/templates/requirements.txt
+++ b/templates/requirements.txt
@@ -1,3 +1,3 @@
-ansible==6.7.0
+ansible==7.0.0
 pynautobot==1.4.0
 pytest==7.3.1

--- a/templates/supervisord.conf
+++ b/templates/supervisord.conf
@@ -21,7 +21,7 @@ minprocs=200                                ; (min. avail process descriptors;de
 serverurl=unix:///var/tmp/supervisor.sock   ; use a unix:// URL  for a unix socket
 
 [program:postgresql-server]
-command=/usr/lib/postgresql/12/bin/postgres -D /var/lib/postgresql/12/main -c config_file=/etc/postgresql/12/main/postgresql.conf
+command=/usr/lib/postgresql/14/bin/postgres -D /var/lib/postgresql/14/main -c config_file=/etc/postgresql/14/main/postgresql.conf
 user=postgres
 autostart=true
 autorestart=true


### PR DESCRIPTION
closes #61 

In my testing, bumping up to Ubuntu 22.04 in the docker image resolves the issue with building on the Apple ARM architecture.